### PR TITLE
bugfix GCC8.2 -Werror=catch-value=

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -232,10 +232,10 @@ int main(int argc, char** argv) {
   // Parse args
   try {
     parser.ParseCLI(argc, argv);
-  } catch (args::Help) {
+  } catch (args::Help &e) {
     std::cout << parser;
     return 0;
-  } catch (args::ParseError e) {
+  } catch (args::ParseError &e) {
     std::cerr << e.what() << std::endl;
     std::cerr << parser;
     return 1;


### PR DESCRIPTION
same as in [https://github.com/nmwsharp/geometry-central/pull/30](https://github.com/nmwsharp/geometry-central/pull/30), fixes a small bug with -Werror in GCC8.2