### PR TITLE
Fix compile error: ambiguous reference to 'Vector3'

### DIFF
--- a/src/point_cloud_utilities.cpp
+++ b/src/point_cloud_utilities.cpp
@@ -27,8 +27,6 @@ std::vector<std::vector<size_t>> generate_knn(const std::vector<Vector3>& points
 
 std::vector<Vector3> generate_normals(const std::vector<Vector3>& points, const Neighbors_t& neigh) {
 
-  using namespace Eigen;
-
   std::vector<Vector3> normals(points.size());
 
   for (size_t iPt = 0; iPt < points.size(); iPt++) {
@@ -42,7 +40,7 @@ std::vector<Vector3> generate_normals(const std::vector<Vector3>& points, const 
     center /= nNeigh + 1;
 
     // Assemble matrix os vectors from centroid
-    MatrixXd localMat(3, neigh[iPt].size());
+    Eigen::MatrixXd localMat(3, neigh[iPt].size());
     for (size_t iN = 0; iN < nNeigh; iN++) {
       Vector3 neighPos = points[neigh[iPt][iN]] - center;
       localMat(0, iN) = neighPos.x;
@@ -51,8 +49,8 @@ std::vector<Vector3> generate_normals(const std::vector<Vector3>& points, const 
     }
 
     // Smallest singular vector is best normal
-    JacobiSVD<MatrixXd> svd(localMat, ComputeThinU);
-    Vector3d bestNormal = svd.matrixU().col(2);
+    Eigen::JacobiSVD<Eigen::MatrixXd> svd(localMat, Eigen::ComputeThinU);
+    Eigen::Vector3d bestNormal = svd.matrixU().col(2);
 
     Vector3 N{bestNormal(0), bestNormal(1), bestNormal(2)};
     N = unit(N);


### PR DESCRIPTION
Fixes ambiguous reference to `Vector3` compilation errors (using gcc 13.2 and Eigen v3.4.0). Both `geometrycentral::Vector3` and `Eigen::Vector3` exist, which causes the symbol confusion.